### PR TITLE
Bump bonnie & Alpine version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ENV BONNIE_VERSION=1.97.3 \
     SHELL=/bin/bash
 
 RUN \
-  apk add --update bash g++ make perl && \
+  apk add --update bash g++ make perl wget openssl && \
   cd /tmp && wget https://www.coker.com.au/bonnie++/bonnie++-${BONNIE_VERSION}.tgz && \
   tar xvf bonnie++-${BONNIE_VERSION}.tgz && cd bonnie++-${BONNIE_VERSION}/ && \
   ./configure && make && make install && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM alpine:3.5
+FROM alpine:3.7
 # Bonnie++ Version can be found on offcial website of bonnie++
 # http://www.coker.com.au/bonnie++/
-ENV BONNIE_VERSION=1.03e \
+ENV BONNIE_VERSION=1.97.3 \
     SHELL=/bin/bash
 
 RUN \
   apk add --update bash g++ make perl && \
-  cd /tmp && wget http://www.coker.com.au/bonnie++/bonnie++-${BONNIE_VERSION}.tgz && \
+  cd /tmp && wget https://www.coker.com.au/bonnie++/bonnie++-${BONNIE_VERSION}.tgz && \
   tar xvf bonnie++-${BONNIE_VERSION}.tgz && cd bonnie++-${BONNIE_VERSION}/ && \
   ./configure && make && make install && \
   rm /tmp/bonnie++-${BONNIE_VERSION}.tgz && \


### PR DESCRIPTION
Noticed that the latest official version of Bonnie++ is already ancient and Linux distros have meanwhile switched to the releases from experimental.

I updated Alpine image and also had to add openssl, because downloading bonnie wouldn't work anymore when building the image.